### PR TITLE
Added ability to toggle all fields from json output, added stopwords.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Hexo (https://hexo.io/) plugin to generate a JSON file for generic use or consumption with the contents of posts and pages.
 
-It's useful to serve compact and agile content data for microservices like AJAX site search or public API.
+It's useful to serve compact and agile content data for microservices like AJAX site search, Twitter typeahead, or public API.
 
 ## Installation
 
@@ -15,7 +15,7 @@ npm i -S hexo-generator-json-content
 Hexo will run the generator *automagically* when you run `hexo serve` or `hexo generate`.
 :)
 
-The `content.json` file will have the following structure:
+Using the default settings, the `content.json` file will have the following structure:
 
 ```javascript
 meta: {
@@ -32,6 +32,7 @@ pages: [{ //-> all pages (optional, configurable)
   updated: page.updated,
   comments: page.comments,
   permalink: page.permalink,
+  path: page.path,
   excerpt: page.excerpt //-> only text ;-)
   text: page.content, //-> only text minified ;-)
   raw: page.raw, //-> original MD (optional, configurable)
@@ -44,6 +45,7 @@ posts: [{ //-> only published posts (optional, configurable)
   updated: post.updated,
   comments: post.comments,
   permalink: post.permalink,
+  path: post.path,
   excerpt: post.excerpt, //-> only text ;-)
   text: post.content, //-> only text minified ;-)
   raw: post.raw, //-> original MD (optional, configurable)
@@ -69,17 +71,91 @@ Default options are as follows:
 
 ```yaml
 jsonContent:
+  meta: true
   pages:
     raw: false
     content: false
+    title: true
+    slug: true
+    date: true
+    updated: true
+    comments: true
+    path: true
+    link: true
+    permalink: true
+    excerpt: true
+    text: true
+    stopwords: true
   posts:
     raw: false
     content: false
+    title: true
+    slug: true
+    date: true
+    updated: true
+    comments: true
+    path: true
+    link: true
+    permalink: true
+    excerpt: true
+    text: true
+    categories: true
+    tags: true
+    stopwords: true
 ```
 
 The `raw` option includes original MARKDOWN string and `content` option includes final HTML string.
 
-You can also exclude pages or posts contents from `content.json` by setting `pages` or `posts` to `false`.
+You can also exclude meta, pages, or posts contents from `content.json` by setting `meta`, `pages`, or `posts` to `false`.
+
+`meta` enables or disables including the `meta` section of the json
+`pages` enables or disables including the `pages` section of the json
+`posts` enables or disables including the `posts` section of the json
+
+To exclude individual fields from output, set their config values to `false`.
+
+## Output Formats
+
+By default, the json output will include the `meta`, `pages`, and `posts` sections. If only 1 section is enabled by config, the json output will consist of a single array.
+
+For example, the following config enables only `posts`, showing the title, date, path, and text fields:
+
+```yaml
+jsonContent:
+  meta: false
+  pages: false
+  posts:
+    title: true
+    date: true
+    path: true
+    text: true
+    raw: false
+    content: false
+    slug: false
+    updated: false
+    comments: false
+    link: false
+    permalink: false
+    excerpt: false
+    categories: false
+    tags: false
+    stopwords: false
+```
+
+The result content.json will include the following format:
+
+```javascript
+[{ //-> only published posts (optional, configurable)
+  title: post.title,
+  date: post.date,
+  text: post.content, //-> text will consist of keywords only, with stopwords removed
+  path: post.path
+}]
+```
+
+## Excluding stopwords
+
+Stopwords can be excluded from the `text` and `excerpt` fields by setting the config value for `stopwords` to `false`. In this case, the text will be stripped down to space-delimited keywords.
 
 ## Examples of use
 

--- a/package.json
+++ b/package.json
@@ -23,5 +23,7 @@
     "url": "https://github.com/alexbruno/hexo-generator-json-content/issues"
   },
   "homepage": "https://github.com/alexbruno/hexo-generator-json-content",
-  "dependencies": []
+  "dependencies": {
+    "keyword-extractor": "*"
+  }
 }


### PR DESCRIPTION
Nice hexo plugin! I made some enhancements to allow for more flexible output.

- Added ability to toggle all fields from json output.
- Added ability to toggle meta, pages, posts section from json output.
- Added support for excluding stop-words from text and excerpt.

I was using this to integrate with Twitter [typeahead](https://twitter.github.io/typeahead.js/) and thought these changes would be handy for other users too.

Note, run `npm install ` when testing this new fork, as it includes a node_module for the stopwords. Thanks.