### PR TITLE
Adds name to registration

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var keywords = require("keyword-extractor");
 
-hexo.extend.generator.register(hexo_generator_json_content);
+hexo.extend.generator.register('json-content', hexo_generator_json_content);
 
 function hexo_generator_json_content(site) {
     var cfg = hexo.config.hasOwnProperty('jsonContent') ? hexo.config.jsonContent : { meta: true },


### PR DESCRIPTION
Makes it possible to look up the generator with hexo.extend.generator.get('json-content') instead of some arbitrary ID.