### PR TITLE
Fix error when pages or posts is set to false in config

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,14 +63,10 @@ function hexo_generator_json_content(site) {
     } : {},
     content;
 
-  var pagesPropertyNames = Object.getOwnPropertyNames(pages).filter(function (item) {
-    return pages[item];
-  });
-  var postsPropertyNames = Object.getOwnPropertyNames(posts).filter(function (item) {
-    return posts[item];
-  });
-
   if (pages) {
+    var pagesPropertyNames = Object.getOwnPropertyNames(pages).filter(function (item) {
+      return pages[item];
+    });
     content = site.pages.map(function (page) {
       var actualPage = {};
       pagesPropertyNames.forEach(function(item){
@@ -94,6 +90,9 @@ function hexo_generator_json_content(site) {
   }
 
   if (posts) {
+    var postsPropertyNames = Object.getOwnPropertyNames(posts).filter(function (item) {
+      return posts[item];
+    });
     content = site.posts.sort('-date').filter(function (post) {
       return post.published;
     }).map(function (post) {


### PR DESCRIPTION
Setting pages or posts to false in config causes fatal error: Object.getOwnPropertyNames called on non-object