### PR TITLE
Fix `post.text` is empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ let cfg = hexo.config.jsonContent || { meta: true },
 				break
 
 			case 'text':
-				obj.content = minify(ref.content)
+				obj.text = minify(ref.content)
 				break
 
 			case 'keywords':


### PR DESCRIPTION
I updated to the latest version found `text` is empty. This change should be right?