### PR TITLE
Use Strict

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+'use strict';
 const util = require('hexo-util'),
 	moment = require('moment'),
 	keywords = require('keyword-extractor'),


### PR DESCRIPTION
Adding line to correct loading issue with node 7.9.0

```
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at Object.exports.runInThisContext (vm.js:53:16)
    at /../hexo-default/node_modules/hexo/lib/hexo/index.js:230:17
    at tryCatcher (/../hexo-default/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/../hexo-default/node_modules/bluebird/js/release/promise.js:512:31)
    at Promise._settlePromise (/../hexo-default/node_modules/bluebird/js/release/promise.js:569:18)
    at Promise._settlePromise0 (/../hexo-default/node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (/../hexo-default/node_modules/bluebird/js/release/promise.js:693:18)
    at Promise._fulfill (/../hexo-default/node_modules/bluebird/js/release/promise.js:638:18)
    at Promise._resolveCallback (/../hexo-default/node_modules/bluebird/js/release/promise.js:432:57)
    at Promise._settlePromiseFromHandler (/../hexo-default/node_modules/bluebird/js/release/promise.js:524:17)
    at Promise._settlePromise (/../hexo-default/node_modules/bluebird/js/release/promise.js:569:18)
    at Promise._settlePromise0 (/../hexo-default/node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (/../hexo-default/node_modules/bluebird/js/release/promise.js:693:18)
    at Promise._fulfill (/../hexo-default/node_modules/bluebird/js/release/promise.js:638:18)
    at /../hexo-default/node_modules/bluebird/js/release/nodeback.js:42:21
    at /../hexo-default/node_modules/graceful-fs/graceful-fs.js:78:16
    at tryToString (fs.js:414:3)
    at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:401:12)
```